### PR TITLE
Fix/manuscripts search date min max filter query and default values

### DIFF
--- a/apps/manuscripts/search.py
+++ b/apps/manuscripts/search.py
@@ -58,8 +58,8 @@ class ManuscriptSearchViewSet(FacetMixin, HaystackViewSet):
 
     def filter_facet_queryset(self, queryset):
         params = self.request.query_params
-        date_min = params.get("date_min")
-        date_max = params.get("date_max")
+        date_min = params.get("min_date")
+        date_max = params.get("max_date")
         at_most_or_least = params.get("at_most_or_least")
         date_diff = params.get("date_diff")
 

--- a/apps/manuscripts/search.py
+++ b/apps/manuscripts/search.py
@@ -77,10 +77,10 @@ class ManuscriptSearchViewSet(FacetMixin, HaystackViewSet):
         # Construct range filters
         range_filter = Q()
         if date_min is not None:
-            range_filter &= Q(date_min__lte=1005)  # date_min <= date_max
+            range_filter &= Q(date_min__gte=date_min)
 
         if date_max is not None:
-            range_filter &= Q(date_max__gte=900)  # date_max >= date_min
+            range_filter &= Q(date_max__lte=date_max)
 
         # Handle precision filters
         precision_filter = Q()

--- a/apps/manuscripts/search_indexes.py
+++ b/apps/manuscripts/search_indexes.py
@@ -38,12 +38,12 @@ class ItemPartIndex(indexes.ModelSearchIndex, indexes.Indexable):
     def prepare_date_min(self, obj):
         if obj.historical_item and obj.historical_item.date and obj.historical_item.date.min_weight:
             return obj.historical_item.date.min_weight
-        return 0  # Default value
+        return None  # Default value
 
     def prepare_date_max(self, obj):
         if obj.historical_item and obj.historical_item.date and obj.historical_item.date.max_weight:
             return obj.historical_item.date.max_weight
-        return 9999  # Default value
+        return None  # Default value
 
 
 class ItemImageIndex(indexes.ModelSearchIndex, indexes.Indexable):


### PR DESCRIPTION
## 🧪 Changes Made
- [ ] [fix: fixed filter_facet_queryset date_min and date_max parameters names](https://github.com/archetype-pal/backend/commit/144086ed4758909217713fec47e111604832a796)
- [ ] [fix: changed the date_min and date_max range filter conditions](https://github.com/archetype-pal/backend/commit/5f1ceff38caceb3ae04f6022d52e3e3e1640faf7)
- [ ] [fix: fixed in search_indexes prepare_date_min and prepare_date_max de…](https://github.com/archetype-pal/backend/commit/888c6e900facb8ed12f62587b6a203672b7f45b7)