### PR TITLE
Close db connection when reindexing

### DIFF
--- a/apps/search/services.py
+++ b/apps/search/services.py
@@ -1,6 +1,7 @@
 """Search and indexing services (Meilisearch)."""
 
 from django.apps import apps
+from django.db import close_old_connections
 
 from apps.search.documents import BUILDERS
 from apps.search.meilisearch.reader import MeilisearchIndexReader
@@ -61,7 +62,8 @@ class IndexingService:
 
         qs = get_queryset_for_index(index_type)
         documents = []
-        for obj in qs.iterator():
+        for obj in qs.iterator(chunk_size=1000):
+            close_old_connections()
             doc = builder(obj)
             documents.append(doc)
 


### PR DESCRIPTION
`IndexingService.reindex` iterates over a queryset and builds documents without closing old DB connections. During long-running reindex tasks (especially in celery), Django can accumulate connections and eventually hit `max_connections`.
This fix adds explicit connection cleanup inside the reindex loop (or per batch). It calls `close_old_connections()` inside `reindex`, and use chunked iteration to avoid building huge lists.