### PR TITLE
feat(annotations): allow TEXT-typed Graphs and add texts dashboard endpoint

### DIFF
--- a/apps/annotations/migrations/0007_graph_text_type_check_constraint.py
+++ b/apps/annotations/migrations/0007_graph_text_type_check_constraint.py
@@ -1,0 +1,31 @@
+"""Permit TEXT-typed Graph rows under the editorial-or-required check.
+
+Migration 0006 made allograph and hand nullable but the accompanying
+CHECK constraint only allowed null FKs when annotation_type=editorial.
+TEXT-typed graphs (regions on an image referenced from ImageText.content
+via data-graph-id attributes) need the same exemption — they have no
+glyph allograph and no scribal hand to attribute.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("annotations", "0006_graph_notes_and_editorial_optional_links"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="graph",
+            name="graph_editorial_or_required_allograph_hand",
+        ),
+        migrations.AddConstraint(
+            model_name="graph",
+            constraint=models.CheckConstraint(
+                condition=models.Q(annotation_type__in=["editorial", "text"])
+                | (models.Q(allograph__isnull=False) & models.Q(hand__isnull=False)),
+                name="graph_editorial_or_required_allograph_hand",
+            ),
+        ),
+    ]

--- a/apps/annotations/models.py
+++ b/apps/annotations/models.py
@@ -12,12 +12,15 @@ class Graph(models.Model):
     annotation = models.JSONField()  # rename this to location
     note = models.TextField(blank=True, default="")
     internal_note = models.TextField(blank=True, default="")
-    # the fields below annotate the graph described by the image and its location above
+    # The paleographic FKs below are required for IMAGE-typed graphs (a glyph
+    # instance with allograph + scribal hand) but null for EDITORIAL and TEXT
+    # rows. TEXT graphs are just regions on the image referenced from
+    # `ImageText.content` via `data-graph-id` attributes on a span.
     allograph = models.ForeignKey("symbols_structure.Allograph", null=True, blank=True, on_delete=models.CASCADE)
     components = models.ManyToManyField(
         "symbols_structure.Component", related_name="graphs", through="GraphComponent", blank=True
     )
-    positions = models.ManyToManyField("symbols_structure.Position", related_name="graphs")
+    positions = models.ManyToManyField("symbols_structure.Position", related_name="graphs", blank=True)
     hand = models.ForeignKey("scribes.Hand", null=True, blank=True, on_delete=models.PROTECT)
 
     annotation_type = models.CharField(
@@ -28,7 +31,7 @@ class Graph(models.Model):
         ordering = ["id"]
         constraints = [
             models.CheckConstraint(
-                condition=models.Q(annotation_type="editorial")
+                condition=models.Q(annotation_type__in=["editorial", "text"])
                 | (models.Q(allograph__isnull=False) & models.Q(hand__isnull=False)),
                 name="graph_editorial_or_required_allograph_hand",
             ),

--- a/apps/manuscripts/migrations/0018_imagetext_unique_per_kind.py
+++ b/apps/manuscripts/migrations/0018_imagetext_unique_per_kind.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+
+
+def _dedupe_image_texts(apps, schema_editor):
+    """Keep the most-recently-modified row per (item_image, type); drop the rest.
+
+    The user's domain has at most one of each kind per image. The dedupe is
+    defensive: it ensures the unique constraint can be added cleanly even on
+    legacy datasets where stray duplicates might exist.
+    """
+    ImageText = apps.get_model("manuscripts", "ImageText")
+    seen: dict[tuple[int, str], int] = {}
+    to_delete: list[int] = []
+    # Iterate newest-first so the first sighting per (item_image, type) wins.
+    for row in ImageText.objects.order_by("-modified", "-id").values("id", "item_image_id", "type"):
+        key = (row["item_image_id"], row["type"])
+        if key in seen:
+            to_delete.append(row["id"])
+        else:
+            seen[key] = row["id"]
+    if to_delete:
+        ImageText.objects.filter(id__in=to_delete).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("manuscripts", "0017_tagulous_itemimage_tags_itemimage_tags"),
+    ]
+
+    operations = [
+        migrations.RunPython(_dedupe_image_texts, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="imagetext",
+            constraint=models.UniqueConstraint(
+                fields=("item_image", "type"),
+                name="imagetext_one_per_kind_per_image",
+            ),
+        ),
+    ]

--- a/apps/manuscripts/models.py
+++ b/apps/manuscripts/models.py
@@ -187,6 +187,12 @@ class ImageText(models.Model):
 
     class Meta:
         ordering = ["-created"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["item_image", "type"],
+                name="imagetext_one_per_kind_per_image",
+            ),
+        ]
 
     def __str__(self) -> str:
         return f"{self.item_image} - {self.get_type_display()}"

--- a/apps/manuscripts/tests/tests.py
+++ b/apps/manuscripts/tests/tests.py
@@ -51,14 +51,25 @@ class ItemImageAPITestCase(APITestCase):
 class PublicImageTextViewSetTestCase(APITestCase):
     def setUp(self):
         self.client = APIClient()
-        self.item_image = ItemImageFactory()
-        self.live = ImageTextFactory(item_image=self.item_image, status=ImageText.Status.LIVE)
-        self.reviewed = ImageTextFactory(item_image=self.item_image, status=ImageText.Status.REVIEWED)
-        self.draft = ImageTextFactory(item_image=self.item_image, status=ImageText.Status.DRAFT)
-        self.review = ImageTextFactory(item_image=self.item_image, status=ImageText.Status.REVIEW)
+        # Two images so we can cover all four statuses without violating the
+        # one-text-per-(image, type) unique constraint introduced in 0020.
+        self.image_a = ItemImageFactory()
+        self.image_b = ItemImageFactory()
+        self.live = ImageTextFactory(
+            item_image=self.image_a, type=ImageText.Type.TRANSCRIPTION, status=ImageText.Status.LIVE
+        )
+        self.reviewed = ImageTextFactory(
+            item_image=self.image_a, type=ImageText.Type.TRANSLATION, status=ImageText.Status.REVIEWED
+        )
+        self.draft = ImageTextFactory(
+            item_image=self.image_b, type=ImageText.Type.TRANSCRIPTION, status=ImageText.Status.DRAFT
+        )
+        self.review = ImageTextFactory(
+            item_image=self.image_b, type=ImageText.Type.TRANSLATION, status=ImageText.Status.REVIEW
+        )
 
     def test_anonymous_only_sees_live_and_reviewed(self):
-        response = self.client.get(f"/api/v1/manuscripts/image-texts/?item_image={self.item_image.id}")
+        response = self.client.get("/api/v1/manuscripts/image-texts/")
         assert response.status_code == status.HTTP_200_OK
         ids = {row["id"] for row in response.data["results"]}
         assert ids == {self.live.id, self.reviewed.id}
@@ -66,7 +77,7 @@ class PublicImageTextViewSetTestCase(APITestCase):
     def test_staff_sees_all_statuses(self):
         staff = User.objects.create_user(username="staff", password="x", is_staff=True)
         self.client.force_authenticate(user=staff)
-        response = self.client.get(f"/api/v1/manuscripts/image-texts/?item_image={self.item_image.id}")
+        response = self.client.get("/api/v1/manuscripts/image-texts/")
         assert response.status_code == status.HTTP_200_OK
         ids = {row["id"] for row in response.data["results"]}
         assert ids == {self.live.id, self.reviewed.id, self.draft.id, self.review.id}
@@ -75,7 +86,7 @@ class PublicImageTextViewSetTestCase(APITestCase):
         response = self.client.get(f"/api/v1/manuscripts/image-texts/{self.live.id}/")
         assert response.status_code == status.HTTP_200_OK
         assert response.data["id"] == self.live.id
-        assert response.data["item_image"] == self.item_image.id
+        assert response.data["item_image"] == self.image_a.id
         assert "content" in response.data
         assert "status" in response.data
 

--- a/apps/search/tests/test_text_monitoring.py
+++ b/apps/search/tests/test_text_monitoring.py
@@ -1,0 +1,142 @@
+"""Tests for the image-text monitoring overview endpoint."""
+
+import pytest
+from rest_framework import status
+
+from apps.manuscripts.models import ImageText
+from apps.manuscripts.tests.factories import ImageTextFactory, ItemImageFactory
+
+URL = "/api/v1/search/management/image-texts/overview/"
+
+
+@pytest.fixture
+def populated_corpus(db):
+    img_a = ItemImageFactory()
+    img_b = ItemImageFactory()
+    img_c = ItemImageFactory()  # has neither
+
+    ImageTextFactory(
+        item_image=img_a,
+        type=ImageText.Type.TRANSCRIPTION,
+        status=ImageText.Status.DRAFT,
+        language="la",
+        content="abc",
+    )
+    ImageTextFactory(
+        item_image=img_a,
+        type=ImageText.Type.TRANSLATION,
+        status=ImageText.Status.LIVE,
+        language="en",
+        content="hello world",
+    )
+    ImageTextFactory(
+        item_image=img_b,
+        type=ImageText.Type.TRANSCRIPTION,
+        status=ImageText.Status.REVIEW,
+        language="",
+        content="",
+    )
+    return {"a": img_a, "b": img_b, "c": img_c}
+
+
+@pytest.mark.django_db
+class TestTextMonitoringOverview:
+    def test_anonymous_is_rejected(self, api_client):
+        response = api_client.get(URL)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_regular_user_is_rejected(self, authenticated_client):
+        response = authenticated_client.get(URL)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_superuser_gets_payload_shape(self, management_client, populated_corpus):
+        response = management_client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert {
+            "generated_at",
+            "matrix",
+            "coverage",
+            "languages",
+            "recent",
+            "activity",
+            "annotation_health",
+        } <= set(body)
+
+        matrix = body["matrix"]
+        assert matrix["kinds"] == [
+            ImageText.Type.TRANSCRIPTION,
+            ImageText.Type.TRANSLATION,
+        ]
+        assert set(matrix["statuses"]) == {
+            ImageText.Status.DRAFT,
+            ImageText.Status.REVIEW,
+            ImageText.Status.LIVE,
+            ImageText.Status.REVIEWED,
+        }
+        # 2 transcriptions, 1 translation in our fixture.
+        assert matrix["totals"][ImageText.Type.TRANSCRIPTION] == 2
+        assert matrix["totals"][ImageText.Type.TRANSLATION] == 1
+        assert matrix["by_kind"][ImageText.Type.TRANSCRIPTION][ImageText.Status.DRAFT] == 1
+        assert matrix["by_kind"][ImageText.Type.TRANSCRIPTION][ImageText.Status.REVIEW] == 1
+        assert matrix["by_kind"][ImageText.Type.TRANSLATION][ImageText.Status.LIVE] == 1
+        # img_b's transcription is empty.
+        assert matrix["empty_by_kind"][ImageText.Type.TRANSCRIPTION] == 1
+        assert matrix["empty_by_kind"][ImageText.Type.TRANSLATION] == 0
+
+    def test_coverage_counts(self, management_client, populated_corpus):
+        response = management_client.get(URL)
+        cov = response.json()["coverage"]
+        assert cov["images_total"] >= 3
+        assert cov["with_transcription"] >= 2
+        assert cov["with_translation"] >= 1
+        assert cov["with_both"] >= 1
+        assert cov["with_either"] >= 2
+        # img_c has no texts.
+        assert cov["with_neither"] >= 1
+
+    def test_languages_breakdown(self, management_client, populated_corpus):
+        response = management_client.get(URL)
+        langs = {row["language"]: row for row in response.json()["languages"]}
+        assert "la" in langs
+        assert langs["la"]["transcription"] == 1
+        assert "en" in langs
+        assert langs["en"]["translation"] == 1
+        # Empty language strings should appear under "(unset)".
+        assert "(unset)" in langs
+        assert langs["(unset)"]["transcription"] >= 1
+
+    def test_recent_activity_has_fields(self, management_client, populated_corpus):
+        response = management_client.get(URL)
+        recent = response.json()["recent"]
+        assert recent, "expected at least one recent edit"
+        for row in recent:
+            assert {
+                "id",
+                "type",
+                "status",
+                "language",
+                "modified",
+                "created",
+                "is_empty",
+                "char_count",
+                "annotation_count",
+                "item_image_id",
+                "item_part_id",
+                "label",
+                "locus",
+            } <= set(row)
+
+    def test_annotation_health(self, management_client, populated_corpus):
+        response = management_client.get(URL)
+        health = response.json()["annotation_health"]
+        assert health["image_texts_total"] >= 3
+        assert health["image_texts_with_content"] >= 2
+        assert health["annotations_total"] >= 0
+        assert health["average_annotations_per_text"] >= 0

--- a/apps/search/text_monitoring_endpoints.py
+++ b/apps/search/text_monitoring_endpoints.py
@@ -1,0 +1,216 @@
+"""Image-text monitoring for the backoffice.
+
+Aggregates the state of every transcription/translation row in the corpus into
+a single dashboard payload: per-status × per-kind matrix, coverage across the
+images that have at least one text, language distribution, and a feed of the
+most-recently edited rows so the editorial team can see who is working on what.
+
+Read-only, superuser-gated, served at
+``/api/v1/search/management/image-texts/overview/``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import timedelta
+from typing import Any
+
+from django.db.models import Count, Exists, OuterRef, Q
+from django.utils import timezone
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+
+from apps.annotations.models import Graph
+from apps.common.permissions import IsSuperuser
+from apps.manuscripts.models import ImageText, ItemImage
+
+KIND_VALUES: tuple[str, ...] = (
+    ImageText.Type.TRANSCRIPTION,
+    ImageText.Type.TRANSLATION,
+)
+STATUS_VALUES: tuple[str, ...] = (
+    ImageText.Status.DRAFT,
+    ImageText.Status.REVIEW,
+    ImageText.Status.LIVE,
+    ImageText.Status.REVIEWED,
+)
+
+
+def _status_matrix() -> dict[str, Any]:
+    """status × kind matrix of counts plus a row-empty bucket per kind."""
+
+    rows = ImageText.objects.values("type", "status").annotate(n=Count("id"))
+    by_kind: dict[str, dict[str, int]] = {kind: dict.fromkeys(STATUS_VALUES, 0) for kind in KIND_VALUES}
+    for row in rows:
+        kind = row["type"]
+        status = row["status"]
+        if kind in by_kind and status in by_kind[kind]:
+            by_kind[kind][status] = row["n"]
+
+    empty_by_kind: dict[str, int] = {}
+    for kind in KIND_VALUES:
+        empty_by_kind[kind] = ImageText.objects.filter(type=kind, content="").count()
+
+    totals = {kind: sum(by_kind[kind].values()) for kind in KIND_VALUES}
+    return {
+        "kinds": list(KIND_VALUES),
+        "statuses": list(STATUS_VALUES),
+        "by_kind": by_kind,
+        "empty_by_kind": empty_by_kind,
+        "totals": totals,
+    }
+
+
+def _coverage() -> dict[str, Any]:
+    """Per-image coverage. How many images have transcription / translation / both."""
+
+    has_transcription = ImageText.objects.filter(item_image_id=OuterRef("pk"), type=ImageText.Type.TRANSCRIPTION)
+    has_translation = ImageText.objects.filter(item_image_id=OuterRef("pk"), type=ImageText.Type.TRANSLATION)
+    qs = ItemImage.objects.annotate(
+        has_transcr=Exists(has_transcription),
+        has_transl=Exists(has_translation),
+    )
+    images_total = qs.count()
+    with_transcr = qs.filter(has_transcr=True).count()
+    with_transl = qs.filter(has_transl=True).count()
+    with_both = qs.filter(has_transcr=True, has_transl=True).count()
+    with_either = qs.filter(Q(has_transcr=True) | Q(has_transl=True)).count()
+    return {
+        "images_total": images_total,
+        "with_transcription": with_transcr,
+        "with_translation": with_transl,
+        "with_both": with_both,
+        "with_either": with_either,
+        "with_neither": images_total - with_either,
+    }
+
+
+def _languages(limit: int = 12) -> list[dict[str, Any]]:
+    """Top languages, with per-kind breakdown."""
+
+    rows = ImageText.objects.exclude(language="").values("language", "type").annotate(n=Count("id"))
+    grouped: dict[str, dict[str, int]] = defaultdict(lambda: dict.fromkeys(KIND_VALUES, 0))
+    for row in rows:
+        grouped[row["language"]][row["type"]] = row["n"]
+    out = [
+        {
+            "language": lang,
+            "transcription": counts.get(ImageText.Type.TRANSCRIPTION, 0),
+            "translation": counts.get(ImageText.Type.TRANSLATION, 0),
+            "total": sum(counts.values()),
+        }
+        for lang, counts in grouped.items()
+    ]
+    out.sort(key=lambda r: r["total"], reverse=True)
+    blank_count = ImageText.objects.filter(language="").count()
+    return (
+        [
+            *out[:limit],
+            {
+                "language": "(unset)",
+                "transcription": ImageText.objects.filter(language="", type=ImageText.Type.TRANSCRIPTION).count(),
+                "translation": ImageText.objects.filter(language="", type=ImageText.Type.TRANSLATION).count(),
+                "total": blank_count,
+            },
+        ]
+        if blank_count
+        else out[:limit]
+    )
+
+
+def _recent_activity(limit: int = 25) -> list[dict[str, Any]]:
+    """The N most-recently modified image-texts, with annotation counts.
+
+    `annotation_count` is the number of TEXT-typed Graphs on the same image —
+    a stand-in for "regions linkable from this text," cheap to compute as a
+    queryset annotation rather than parsing `data-graph-id` out of each
+    row's HTML.
+    """
+
+    qs = (
+        ImageText.objects.select_related("item_image", "item_image__item_part")
+        .annotate(
+            annotation_count=Count(
+                "item_image__graphs",
+                filter=Q(item_image__graphs__annotation_type="text"),
+            )
+        )
+        .order_by("-modified")[:limit]
+    )
+    out: list[dict[str, Any]] = []
+    for it in qs:
+        ip = it.item_image
+        item_part = getattr(ip, "item_part", None)
+        out.append(
+            {
+                "id": it.id,
+                "type": it.type,
+                "status": it.status,
+                "language": it.language,
+                "modified": it.modified.isoformat(),
+                "created": it.created.isoformat(),
+                "is_empty": not it.content,
+                "char_count": len(it.content),
+                "annotation_count": it.annotation_count,
+                "item_image_id": ip.id,
+                "item_part_id": item_part.id if item_part else None,
+                "locus": ip.locus or "",
+                "label": str(ip),
+            }
+        )
+    return out
+
+
+def _activity_buckets(days: int = 30) -> list[dict[str, Any]]:
+    """Daily edit volume for the last ``days`` days, grouped by kind."""
+
+    cutoff = timezone.now() - timedelta(days=days)
+    qs = ImageText.objects.filter(modified__gte=cutoff).values("type", "modified")
+    buckets: dict[str, dict[str, int]] = defaultdict(lambda: dict.fromkeys(KIND_VALUES, 0))
+    for row in qs:
+        day = row["modified"].date().isoformat()
+        kind = row["type"]
+        if kind in KIND_VALUES:
+            buckets[day][kind] = buckets[day].get(kind, 0) + 1
+    return [
+        {
+            "date": day,
+            "transcription": counts.get(ImageText.Type.TRANSCRIPTION, 0),
+            "translation": counts.get(ImageText.Type.TRANSLATION, 0),
+        }
+        for day, counts in sorted(buckets.items())
+    ]
+
+
+def _annotation_health() -> dict[str, Any]:
+    """Quick read on how well-annotated the corpus' texts are.
+
+    A text annotation is a TEXT-typed Graph row — a region on an image that
+    `ImageText.content` references via a `data-graph-id` attribute on a span.
+    """
+
+    total = ImageText.objects.count()
+    with_content = ImageText.objects.exclude(content="").count()
+    annotations_total = Graph.objects.filter(annotation_type=Graph.AnnotationType.TEXT).count()
+    return {
+        "image_texts_total": total,
+        "image_texts_with_content": with_content,
+        "annotations_total": annotations_total,
+        "average_annotations_per_text": (round(annotations_total / with_content, 2) if with_content else 0.0),
+    }
+
+
+@api_view(["GET"])
+@permission_classes([IsSuperuser])
+def text_monitoring_overview(request):
+    return Response(
+        {
+            "generated_at": timezone.now().isoformat(),
+            "matrix": _status_matrix(),
+            "coverage": _coverage(),
+            "languages": _languages(),
+            "recent": _recent_activity(),
+            "activity": _activity_buckets(),
+            "annotation_health": _annotation_health(),
+        }
+    )

--- a/apps/search/urls.py
+++ b/apps/search/urls.py
@@ -2,6 +2,7 @@
 
 from django.urls import path
 
+from apps.search.text_monitoring_endpoints import text_monitoring_overview
 from apps.search.views_management import search_action, search_stats, search_task_status
 from apps.search.views_search import SearchSuggestViewSet, SearchViewSet
 
@@ -9,6 +10,11 @@ urlpatterns = [
     path("management/stats/", search_stats, name="management-search-stats"),
     path("management/actions/", search_action, name="management-search-actions"),
     path("management/tasks/<str:task_id>/", search_task_status, name="management-search-task-status"),
+    path(
+        "management/image-texts/overview/",
+        text_monitoring_overview,
+        name="management-image-texts-overview",
+    ),
     path("suggest/", SearchSuggestViewSet.as_view({"get": "list"}), name="search-suggest"),
     path("<index_type>/export/", SearchViewSet.as_view({"get": "export"}), name="search-export"),
     path("<index_type>/facets/", SearchViewSet.as_view({"get": "facets"}), name="search-facets"),


### PR DESCRIPTION
## Summary

Refactor of the original "TextAnnotation model" approach — replaced with the much smaller change of letting `Graph` itself hold text-typed regions, since it already had `annotation_type` with a `TEXT` choice that nothing wrote to.

Builds on `0006_graph_notes_and_editorial_optional_links` which already made `allograph` and `hand` nullable but only allowed null FKs when `annotation_type=editorial`. This PR extends the exemption to `text` so TEXT-typed Graphs (regions on an image referenced from `ImageText.content` via `data-graph-id` attributes) can also exist without a glyph allograph or scribal hand.

- `apps/annotations/models.py` — Meta CHECK constraint widened to `Q(annotation_type__in=["editorial", "text"]) | (allograph__isnull=False & hand__isnull=False)`. Comment block on the FK lines explains when null is allowed.
- `apps/annotations/migrations/0007_graph_text_type_check_constraint.py` — drops the old constraint, re-adds the widened one.
- `apps/manuscripts/migrations/0018_imagetext_unique_per_kind.py` — `UniqueConstraint(item_image, type)` on `ImageText`. The data model has at most one Transcription/Translation per image; the constraint enforces it at the DB level so we don't have to police it from application code. Includes a defensive `RunPython` dedupe in case any prod row violates it pre-migration.
- `apps/manuscripts/tests/tests.py` — `PublicImageTextViewSetTestCase.setUp` reshaped to use two images so it still covers all four statuses under the new uniqueness rule.
- `apps/search/text_monitoring_endpoints.py` — new endpoint at `/api/v1/search/management/image-texts/overview/` aggregating the per-kind × per-status matrix, image coverage, language distribution, recent edits, and annotation health (counts TEXT-typed Graph rows). This powers the `/backoffice/texts` dashboard on the frontend.

The text remains the single source of truth for what's linked: each marked-up span in `ImageText.content` carries its semantic role (`data-dpt="clause"`, `data-type="address"`) and the polygon reference (`data-graph-id="42"`) on the same span. One span may reference multiple graphs (e.g. a sentence that wraps across a fold) — the editor will surface that as a comma-separated id list in a follow-up. Dangling references (graph deleted, attribute lingers in HTML) are tolerated; the renderer just ignores them.

The IMAGE-typed Graph create paths in `apps/annotations/serializers.py` already hard-code `annotation_type = IMAGE` and won't accept null FKs, so existing glyph workflows are unchanged.

## Test plan

- [x] `pytest apps/manuscripts/ apps/search/ apps/common/ apps/annotations/` — 67 pass, 1 skip (SQLite, outside Docker)
- [x] `ruff check` and `ruff format --check` — clean
- [ ] `just pytest` — full suite under Postgres + Meilisearch
- [ ] Migrate against the dev DB and exercise the dashboard endpoint
- [ ] Create a TEXT-typed Graph (no allograph, no hand) via the existing Graph admin/management endpoint and confirm it persists, and that an IMAGE-typed Graph without those FKs still fails the CHECK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
