### PR TITLE
feat(backoffice): review queue, status transitions, and quality dashboard

### DIFF
--- a/apps/manuscripts/migrations/0019_imagetext_review_assignee_statustransition.py
+++ b/apps/manuscripts/migrations/0019_imagetext_review_assignee_statustransition.py
@@ -1,0 +1,81 @@
+# Phase G — review queue.
+# Adds the `review_assignee` FK to ImageText (who the editor nominated to
+# review a draft) and the `StatusTransition` audit table.
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("manuscripts", "0018_imagetext_unique_per_kind"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="imagetext",
+            name="review_assignee",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="image_texts_assigned_for_review",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.CreateModel(
+            name="StatusTransition",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "from_status",
+                    models.CharField(
+                        choices=[
+                            ("Draft", "Draft"),
+                            ("Review", "Review"),
+                            ("Live", "Live"),
+                            ("Reviewed", "Reviewed"),
+                        ],
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "to_status",
+                    models.CharField(
+                        choices=[
+                            ("Draft", "Draft"),
+                            ("Review", "Review"),
+                            ("Live", "Live"),
+                            ("Reviewed", "Reviewed"),
+                        ],
+                        max_length=16,
+                    ),
+                ),
+                ("note", models.TextField(blank=True, default="")),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="status_transitions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "image_text",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="status_transitions",
+                        to="manuscripts.imagetext",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created"],
+                "indexes": [models.Index(fields=["image_text", "-created"], name="manuscripts_image_t_430251_idx")],
+            },
+        ),
+    ]

--- a/apps/manuscripts/models.py
+++ b/apps/manuscripts/models.py
@@ -182,6 +182,18 @@ class ImageText(models.Model):
     type = models.CharField(max_length=32, choices=Type.choices)
     status = models.CharField(max_length=16, choices=Status.choices)
     language = models.CharField(max_length=100, blank=True, default="")
+    # Phase G — when an editor sends a draft to a reviewer, we record who
+    # they nominated. Cleared when the row leaves Review (back to Draft
+    # or onward to Live). Doesn't constrain who *can* approve — any
+    # is_staff user can — but it makes the queue UI honest about who's
+    # expected to look at it.
+    review_assignee = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="image_texts_assigned_for_review",
+    )
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
@@ -196,3 +208,31 @@ class ImageText(models.Model):
 
     def __str__(self) -> str:
         return f"{self.item_image} - {self.get_type_display()}"
+
+
+class StatusTransition(models.Model):
+    """Phase G — audit log of every status change on an `ImageText`.
+
+    Records the editorial-state transitions specifically (Draft → Review
+    → Live → Reviewed) so the reviewer queue can show "who sent this for
+    review when, with what note."
+    """
+
+    image_text = models.ForeignKey(ImageText, related_name="status_transitions", on_delete=models.CASCADE)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="status_transitions",
+    )
+    from_status = models.CharField(max_length=16, choices=ImageText.Status.choices)
+    to_status = models.CharField(max_length=16, choices=ImageText.Status.choices)
+    note = models.TextField(blank=True, default="")
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created"]
+        indexes = [models.Index(fields=["image_text", "-created"])]
+
+    def __str__(self) -> str:
+        return f"#{self.pk} {self.image_text_id} {self.from_status}→{self.to_status} by user={self.actor_id}"

--- a/apps/manuscripts/serializers/management.py
+++ b/apps/manuscripts/serializers/management.py
@@ -43,6 +43,9 @@ class CurrentItemManagementSerializer(serializers.ModelSerializer):
 
 
 class ImageTextManagementSerializer(serializers.ModelSerializer):
+    review_assignee_username = serializers.CharField(source="review_assignee.username", read_only=True, default=None)
+    last_transition = serializers.SerializerMethodField()
+
     class Meta:
         model = ImageText
         fields = [
@@ -52,10 +55,27 @@ class ImageTextManagementSerializer(serializers.ModelSerializer):
             "type",
             "status",
             "language",
+            "review_assignee",
+            "review_assignee_username",
+            "last_transition",
             "created",
             "modified",
         ]
-        read_only_fields = ["created", "modified"]
+        read_only_fields = ["created", "modified", "last_transition", "review_assignee_username"]
+
+    def get_last_transition(self, obj) -> dict | None:
+        last = obj.status_transitions.first() if hasattr(obj, "status_transitions") else None
+        if not last:
+            return None
+        return {
+            "id": last.id,
+            "from_status": last.from_status,
+            "to_status": last.to_status,
+            "actor": last.actor_id,
+            "actor_username": last.actor.username if last.actor_id else None,
+            "note": last.note,
+            "created": last.created.isoformat(),
+        }
 
 
 class ItemImageManagementSerializer(serializers.ModelSerializer):

--- a/apps/manuscripts/tests/test_review_queue.py
+++ b/apps/manuscripts/tests/test_review_queue.py
@@ -1,0 +1,88 @@
+"""Phase G — reviewer queue + status transition tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.manuscripts.models import ImageText, StatusTransition
+from apps.manuscripts.tests.factories import ImageTextFactory
+
+
+@pytest.mark.django_db
+class TestReviewQueue:
+    def test_queue_only_shows_review_status(self, management_client):
+        ImageTextFactory(status=ImageText.Status.DRAFT)
+        ImageTextFactory(status=ImageText.Status.REVIEW)
+        ImageTextFactory(status=ImageText.Status.LIVE)
+        response = management_client.get("/api/v1/manuscripts/management/review-queue/")
+        assert response.status_code == 200
+        statuses = {row["status"] for row in response.json()}
+        assert statuses == {ImageText.Status.REVIEW}
+
+    def test_queue_orders_oldest_first(self, management_client):
+        # Two reviews — older one should sort first.
+        old = ImageTextFactory(status=ImageText.Status.REVIEW)
+        new = ImageTextFactory(status=ImageText.Status.REVIEW)
+        # Force `modified` ordering deterministically.
+        ImageText.objects.filter(pk=old.pk).update(modified="2026-01-01T00:00:00Z")
+        ImageText.objects.filter(pk=new.pk).update(modified="2026-04-01T00:00:00Z")
+        response = management_client.get("/api/v1/manuscripts/management/review-queue/")
+        ids = [row["id"] for row in response.json()]
+        assert ids[0] == old.pk
+        assert ids[-1] == new.pk
+
+    def test_anonymous_cannot_see_queue(self, api_client):
+        response = api_client.get("/api/v1/manuscripts/management/review-queue/")
+        assert response.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+class TestStatusTransition:
+    def test_transition_records_audit_row(self, management_client):
+        text = ImageTextFactory(status=ImageText.Status.DRAFT)
+        response = management_client.post(
+            f"/api/v1/manuscripts/management/image-texts/{text.pk}/transition/",
+            data={"to_status": ImageText.Status.REVIEW, "note": "ready"},
+            format="json",
+        )
+        assert response.status_code == 200, response.json()
+        text.refresh_from_db()
+        assert text.status == ImageText.Status.REVIEW
+        rows = StatusTransition.objects.filter(image_text=text).all()
+        assert rows.count() == 1
+        assert rows[0].from_status == ImageText.Status.DRAFT
+        assert rows[0].to_status == ImageText.Status.REVIEW
+        assert rows[0].note == "ready"
+
+    def test_transition_to_review_can_assign(self, management_client, django_user_model):
+        text = ImageTextFactory(status=ImageText.Status.DRAFT)
+        reviewer = django_user_model.objects.create_user(username="reviewer", is_staff=True)
+        response = management_client.post(
+            f"/api/v1/manuscripts/management/image-texts/{text.pk}/transition/",
+            data={"to_status": ImageText.Status.REVIEW, "assignee": reviewer.pk},
+            format="json",
+        )
+        assert response.status_code == 200
+        text.refresh_from_db()
+        assert text.review_assignee_id == reviewer.pk
+
+    def test_transition_clears_assignee_when_leaving_review(self, management_client, django_user_model):
+        reviewer = django_user_model.objects.create_user(username="reviewer", is_staff=True)
+        text = ImageTextFactory(status=ImageText.Status.REVIEW, review_assignee=reviewer)
+        response = management_client.post(
+            f"/api/v1/manuscripts/management/image-texts/{text.pk}/transition/",
+            data={"to_status": ImageText.Status.LIVE},
+            format="json",
+        )
+        assert response.status_code == 200
+        text.refresh_from_db()
+        assert text.review_assignee_id is None
+
+    def test_transition_rejects_unknown_status(self, management_client):
+        text = ImageTextFactory(status=ImageText.Status.DRAFT)
+        response = management_client.post(
+            f"/api/v1/manuscripts/management/image-texts/{text.pk}/transition/",
+            data={"to_status": "Bogus"},
+            format="json",
+        )
+        assert response.status_code == 400

--- a/apps/manuscripts/urls.py
+++ b/apps/manuscripts/urls.py
@@ -15,6 +15,7 @@ from .views import (
     ItemPartManagementViewSet,
     ItemPartViewSet,
     RepositoryManagementViewSet,
+    ReviewQueueViewSet,
     image_picker_content,
 )
 
@@ -40,6 +41,7 @@ router.register("management/repositories", RepositoryManagementViewSet, basename
 router.register("management/current-items", CurrentItemManagementViewSet, basename="management-current-items")
 router.register("management/sources", BibliographicSourceManagementViewSet, basename="management-sources")
 router.register("management/formats", ItemFormatManagementViewSet, basename="management-formats")
+router.register("management/review-queue", ReviewQueueViewSet, basename="management-review-queue")
 urlpatterns = router.urls + [
     path("management/image-picker-content/", image_picker_content, name="management-image-picker-content"),
 ]

--- a/apps/manuscripts/views.py
+++ b/apps/manuscripts/views.py
@@ -1,7 +1,9 @@
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Count, QuerySet
 from django_filters import rest_framework as filters
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework import status
+from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -150,7 +152,62 @@ class ItemImageManagementViewSet(FilterablePrivilegedViewSet):
 class ImageTextManagementViewSet(FilterablePrivilegedViewSet):
     queryset = ImageText.objects.select_related("item_image").all()
     serializer_class = ImageTextManagementSerializer
-    filterset_fields = ["item_image"]
+    filterset_fields = ["item_image", "status", "type", "review_assignee"]
+
+    @action(detail=True, methods=["post"], url_path="transition")
+    def transition(self, request: Request, pk=None) -> Response:
+        """Phase G — explicit status transition with audit trail.
+
+        Body: ``{"to_status": "Review", "note": "...", "assignee": <user_id?>}``
+        Records a `StatusTransition` row, optionally assigns a reviewer.
+        """
+        from .models import StatusTransition
+
+        text = self.get_object()
+        to_status = request.data.get("to_status")
+        if to_status not in ImageText.Status.values:
+            return Response({"detail": "Unknown status."}, status=status.HTTP_400_BAD_REQUEST)
+        from_status = text.status
+        note = request.data.get("note", "")
+        assignee_id = request.data.get("assignee")
+
+        with transaction.atomic():
+            text.status = to_status
+            if to_status == ImageText.Status.REVIEW and assignee_id:
+                text.review_assignee_id = assignee_id
+            elif to_status != ImageText.Status.REVIEW:
+                # Clear the assignee once the row leaves Review.
+                text.review_assignee = None
+            text.save(update_fields=["status", "review_assignee", "modified"])
+            StatusTransition.objects.create(
+                image_text=text,
+                actor=request.user if request.user.is_authenticated else None,
+                from_status=from_status,
+                to_status=to_status,
+                note=note,
+            )
+        return Response(self.get_serializer(text).data)
+
+
+class ReviewQueueViewSet(GenericViewSet, ListModelMixin):
+    """Phase G.1 — read-only feed of `ImageText` rows in `Review` status.
+
+    Used by `/backoffice/review-queue`. Sorted by oldest-pending-first
+    so reviewers don't lose track of the long tail. Each row carries
+    the latest transition (who sent it, when, with what note) so the
+    UI doesn't need a second round trip.
+    """
+
+    serializer_class = ImageTextManagementSerializer
+    permission_classes = [IsSuperuser]
+    pagination_class = None
+
+    def get_queryset(self):
+        return (
+            ImageText.objects.filter(status=ImageText.Status.REVIEW)
+            .select_related("item_image", "review_assignee")
+            .order_by("modified")
+        )
 
 
 class CatalogueNumberManagementViewSet(FilterablePrivilegedViewSet):

--- a/apps/search/quality_endpoints.py
+++ b/apps/search/quality_endpoints.py
@@ -1,0 +1,112 @@
+"""Data-quality probes for the backoffice dashboard (M8.4).
+
+Each function returns a small dict that the dashboard renders as a card.
+The endpoint at /api/v1/manuscripts/management/quality/ aggregates them.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.db.models import Count
+from django.utils import timezone
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+
+from apps.annotations.models import Graph
+from apps.common.permissions import IsSuperuser
+from apps.manuscripts.models import ImageText
+
+
+def _stale_drafts(days: int = 30) -> dict:
+    cutoff = timezone.now() - timedelta(days=days)
+    qs = ImageText.objects.filter(status=ImageText.Status.DRAFT, modified__lt=cutoff)
+    return {
+        "id": "stale-drafts",
+        "label": f"Image-texts stuck in Draft >{days}d",
+        "count": qs.count(),
+        "sample": [
+            {"id": r.id, "item_image": r.item_image_id, "modified": r.modified.isoformat()}
+            for r in qs.order_by("modified")[:10]
+        ],
+    }
+
+
+def _untyped_clauses() -> dict:
+    """Image-texts whose data-dpt clauses have no `data-dpt-type` attribute.
+
+    We don't pre-compute this; instead we sample the most recent 200 image-texts
+    and run the parser server-side. Gives a "good enough" snapshot for the
+    dashboard without scanning the entire corpus.
+    """
+    from apps.search.documents.dpt_parser import extract_clauses
+
+    flagged: list[dict] = []
+    for it in ImageText.objects.exclude(content="").order_by("-modified")[:200]:
+        clauses = extract_clauses(it.content)
+        without_type = [c for c in clauses if not c.get("type")]
+        if without_type:
+            flagged.append({"id": it.id, "count": len(without_type)})
+    return {
+        "id": "untyped-clauses",
+        "label": "Recent image-texts with untyped clauses",
+        "count": len(flagged),
+        "sample": flagged[:10],
+    }
+
+
+def _undescribed_graphs() -> dict:
+    qs = Graph.objects.annotate(component_count=Count("graphcomponent")).filter(component_count=0).order_by("-id")
+    return {
+        "id": "undescribed-graphs",
+        "label": "Graphs with no components",
+        "count": qs.count(),
+        "sample": [{"id": g.id, "item_image": g.item_image_id} for g in qs[:10]],
+    }
+
+
+def _hands_without_images() -> dict:
+    from apps.scribes.models import Hand
+
+    qs = Hand.objects.annotate(image_count=Count("item_part_images")).filter(image_count=0)
+    return {
+        "id": "hands-without-images",
+        "label": "Hands with no attributed images",
+        "count": qs.count(),
+        "sample": [{"id": h.id, "name": h.name} for h in qs[:10]],
+    }
+
+
+def _orphan_text_graphs() -> dict:
+    """TEXT-typed Graphs sitting on images whose ImageTexts are all empty.
+
+    A TEXT graph is a region referenced from an ImageText.content span via
+    `data-graph-id`. If every text on its image is blank, nothing can refer
+    to it — that's a likely orphan.
+    """
+    qs = Graph.objects.filter(annotation_type=Graph.AnnotationType.TEXT).exclude(
+        item_image__texts__content__regex=r".+"
+    )
+    return {
+        "id": "orphan-text-graphs",
+        "label": "TEXT-typed graphs on images with no text content",
+        "count": qs.count(),
+        "sample": [{"id": r.id, "item_image": r.item_image_id} for r in qs[:10]],
+    }
+
+
+@api_view(["GET"])
+@permission_classes([IsSuperuser])
+def quality_dashboard(request):
+    return Response(
+        {
+            "generated_at": timezone.now().isoformat(),
+            "cards": [
+                _stale_drafts(),
+                _untyped_clauses(),
+                _undescribed_graphs(),
+                _hands_without_images(),
+                _orphan_text_graphs(),
+            ],
+        }
+    )

--- a/apps/search/urls.py
+++ b/apps/search/urls.py
@@ -2,6 +2,7 @@
 
 from django.urls import path
 
+from apps.search.quality_endpoints import quality_dashboard
 from apps.search.text_monitoring_endpoints import text_monitoring_overview
 from apps.search.views_management import search_action, search_stats, search_task_status
 from apps.search.views_search import SearchSuggestViewSet, SearchViewSet
@@ -10,6 +11,7 @@ urlpatterns = [
     path("management/stats/", search_stats, name="management-search-stats"),
     path("management/actions/", search_action, name="management-search-actions"),
     path("management/tasks/<str:task_id>/", search_task_status, name="management-search-task-status"),
+    path("management/quality/", quality_dashboard, name="management-quality"),
     path(
         "management/image-texts/overview/",
         text_monitoring_overview,


### PR DESCRIPTION
## Summary

Three management-only surfaces consumed by the new backoffice pages on the frontend (`/backoffice/review-queue`, `/backoffice/quality`). All endpoints are gated to staff/superusers; nothing here changes the public read API.

### 1. Review queue (Phase G)

- `ImageText.review_assignee` FK records who an editor nominated to review a draft. Cleared automatically when the row leaves `Review`.
- `StatusTransition` model — audit log of every status change (Draft → Review → Live → Reviewed) with actor + note.
- `ImageTextManagementViewSet.transition` action moves a row between statuses in a single transaction, recording the transition and clearing/setting the assignee as appropriate.
- `ReviewQueueViewSet` at `/api/v1/manuscripts/management/review-queue/` — read-only feed of `Review`-status rows, oldest-first.

### 2. Status/type/assignee filters on `ImageTextManagementViewSet`

- Added `status`, `type`, `review_assignee` to `filterset_fields` so the editor list page can narrow by Draft, Translation, etc.
- Added `review_assignee_username` and `last_transition` read-only fields to `ImageTextManagementSerializer`.

### 3. Quality dashboard

- `apps/search/quality_endpoints.py` — read-only summary of data hygiene cards: stale drafts, untyped clauses, undescribed graphs, hands without graphs, orphan TEXT-typed graphs (regions on text-empty images).
- Endpoint at `/api/v1/search/management/quality/`, superuser-gated.

## Test plan

- [x] `pytest apps/` — 90 pass, 1 skip
- [x] `ruff check` and `ruff format --check` — clean
- [ ] `just pytest` — full suite under Postgres + Meilisearch
- [ ] Migrate against the dev DB, send a draft to Review through `/transition/`, verify the queue feed and the `last_transition` payload
- [ ] Hit `/api/v1/search/management/quality/` as a superuser and verify the cards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
