### PR TITLE
feat(backoffice): sole-image-text read + upsert endpoints

### DIFF
--- a/apps/manuscripts/tests/test_sole_image_text.py
+++ b/apps/manuscripts/tests/test_sole_image_text.py
@@ -1,0 +1,99 @@
+"""Tests for the `sole_image_text` (read) and `upsert_sole_image_text` (write) endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework import status
+
+from apps.manuscripts.models import ImageText
+from apps.manuscripts.tests.factories import ImageTextFactory, ItemImageFactory
+
+
+@pytest.mark.django_db
+class TestSoleImageTextRead:
+    def test_anonymous_sees_live_text(self, api_client):
+        image = ItemImageFactory()
+        live = ImageTextFactory(item_image=image, type=ImageText.Type.TRANSCRIPTION, status=ImageText.Status.LIVE)
+        response = api_client.get(f"/api/v1/manuscripts/item-images/{image.id}/transcription/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == live.id
+
+    def test_anonymous_does_not_see_draft(self, api_client):
+        image = ItemImageFactory()
+        ImageTextFactory(item_image=image, type=ImageText.Type.TRANSCRIPTION, status=ImageText.Status.DRAFT)
+        response = api_client.get(f"/api/v1/manuscripts/item-images/{image.id}/transcription/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_staff_sees_draft(self, management_client):
+        image = ItemImageFactory()
+        draft = ImageTextFactory(item_image=image, type=ImageText.Type.TRANSCRIPTION, status=ImageText.Status.DRAFT)
+        response = management_client.get(f"/api/v1/manuscripts/item-images/{image.id}/transcription/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == draft.id
+
+    def test_unknown_kind_is_400(self, api_client):
+        image = ItemImageFactory()
+        response = api_client.get(f"/api/v1/manuscripts/item-images/{image.id}/notathing/")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+class TestUpsertSoleImageText:
+    def test_anonymous_is_forbidden(self, api_client):
+        image = ItemImageFactory()
+        response = api_client.put(
+            f"/api/v1/manuscripts/management/item-images/{image.id}/transcription/",
+            data={"content": "hello"},
+            format="json",
+        )
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    def test_creates_when_missing(self, management_client):
+        image = ItemImageFactory()
+        response = management_client.put(
+            f"/api/v1/manuscripts/management/item-images/{image.id}/transcription/",
+            data={"content": "hello", "language": "la"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.data
+        assert ImageText.objects.filter(item_image=image, type=ImageText.Type.TRANSCRIPTION).count() == 1
+        row = ImageText.objects.get(item_image=image, type=ImageText.Type.TRANSCRIPTION)
+        assert row.content == "hello"
+        assert row.language == "la"
+        assert row.status == ImageText.Status.DRAFT  # default
+
+    def test_updates_when_present(self, management_client):
+        image = ItemImageFactory()
+        existing = ImageTextFactory(
+            item_image=image,
+            type=ImageText.Type.TRANSCRIPTION,
+            content="old",
+            status=ImageText.Status.LIVE,
+        )
+        response = management_client.put(
+            f"/api/v1/manuscripts/management/item-images/{image.id}/transcription/",
+            data={"content": "new", "status": ImageText.Status.LIVE},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.data
+        existing.refresh_from_db()
+        assert existing.content == "new"
+        # Still exactly one row — uniqueness preserved.
+        assert ImageText.objects.filter(item_image=image, type=ImageText.Type.TRANSCRIPTION).count() == 1
+
+    def test_unknown_image_is_404(self, management_client):
+        response = management_client.put(
+            "/api/v1/manuscripts/management/item-images/9999/transcription/",
+            data={"content": "x"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unknown_kind_is_400(self, management_client):
+        image = ItemImageFactory()
+        response = management_client.put(
+            f"/api/v1/manuscripts/management/item-images/{image.id}/notathing/",
+            data={"content": "x"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/apps/manuscripts/urls.py
+++ b/apps/manuscripts/urls.py
@@ -17,6 +17,8 @@ from .views import (
     RepositoryManagementViewSet,
     ReviewQueueViewSet,
     image_picker_content,
+    sole_image_text,
+    upsert_sole_image_text,
 )
 
 router = DefaultRouter()
@@ -44,4 +46,14 @@ router.register("management/formats", ItemFormatManagementViewSet, basename="man
 router.register("management/review-queue", ReviewQueueViewSet, basename="management-review-queue")
 urlpatterns = router.urls + [
     path("management/image-picker-content/", image_picker_content, name="management-image-picker-content"),
+    path(
+        "item-images/<int:item_image_id>/<slug:kind>/",
+        sole_image_text,
+        name="item-image-sole-text",
+    ),
+    path(
+        "management/item-images/<int:item_image_id>/<slug:kind>/",
+        upsert_sole_image_text,
+        name="management-item-image-sole-text",
+    ),
 ]

--- a/apps/manuscripts/views.py
+++ b/apps/manuscripts/views.py
@@ -85,6 +85,65 @@ class ImageTextViewSet(GenericViewSet, ListModelMixin, RetrieveModelMixin):
         return queryset
 
 
+def _kind_from_slug(slug: str) -> str | None:
+    """Map ``"transcription"`` / ``"translation"`` URL segments to the model enum value."""
+    if slug == "transcription":
+        return ImageText.Type.TRANSCRIPTION
+    if slug == "translation":
+        return ImageText.Type.TRANSLATION
+    return None
+
+
+@api_view(["GET"])
+@permission_classes([])
+def sole_image_text(request: Request, item_image_id: int, kind: str) -> Response:
+    """Return the single ``ImageText`` of the requested *kind* for *item_image_id*.
+
+    Public read; anonymous callers see the row only when it is Live or Reviewed.
+    Returns 404 when the row does not exist (callers treat that as "empty
+    editor"; no creation occurs on read).
+    """
+    type_value = _kind_from_slug(kind)
+    if type_value is None:
+        return Response({"detail": "Unknown kind."}, status=400)
+    qs = ImageText.objects.filter(item_image_id=item_image_id, type=type_value)
+    user = request.user
+    if not (user.is_authenticated and user.is_staff):
+        qs = qs.filter(status__in=[ImageText.Status.LIVE, ImageText.Status.REVIEWED])
+    row = qs.first()
+    if row is None:
+        return Response({"detail": "Not found."}, status=404)
+    return Response(ImageTextDetailSerializer(row).data)
+
+
+@api_view(["PUT"])
+@permission_classes([IsSuperuser])
+def upsert_sole_image_text(request: Request, item_image_id: int, kind: str) -> Response:
+    """Idempotently upsert the ``ImageText`` of *kind* for *item_image_id*.
+
+    The (item_image, type) uniqueness invariant means there is at most one row;
+    this endpoint is the simple way the frontend writes either editor without
+    knowing or caring about its database id.
+    """
+    type_value = _kind_from_slug(kind)
+    if type_value is None:
+        return Response({"detail": "Unknown kind."}, status=400)
+    if not ItemImage.objects.filter(pk=item_image_id).exists():
+        return Response({"detail": "Unknown item_image."}, status=404)
+    payload = request.data or {}
+    defaults = {
+        "content": payload.get("content", ""),
+        "status": payload.get("status", ImageText.Status.DRAFT),
+        "language": payload.get("language", ""),
+    }
+    row, _ = ImageText.objects.update_or_create(
+        item_image_id=item_image_id,
+        type=type_value,
+        defaults=defaults,
+    )
+    return Response(ImageTextManagementSerializer(row).data)
+
+
 @api_view(["GET"])
 @permission_classes([IsSuperuser])
 def image_picker_content(request: Request) -> Response:


### PR DESCRIPTION
## Summary

Two endpoints that lean on the `(item_image, type)` uniqueness invariant introduced in #94's migration 0018. They let the backoffice ImageText editor save without tracking row ids, and let any reader fetch "the transcription for this image" by URL.

### `GET /api/v1/manuscripts/item-images/<id>/<kind>/`

- Public read with the same visibility rule as the existing `ImageTextViewSet`: anonymous callers see only `Live`/`Reviewed`, staff see everything.
- 404 when the row doesn't exist — the frontend editor treats this as "empty editor, nothing to load", no implicit creation.
- `<kind>` is the slug `transcription` or `translation`; anything else is a 400.

### `PUT /api/v1/manuscripts/management/item-images/<id>/<kind>/`

- `IsSuperuser`-gated idempotent upsert.
- Body: `{ "content": str, "status"?: ImageText.Status, "language"?: str }`. Defaults: empty content, `Draft`, empty language.
- Uses `update_or_create` keyed on `(item_image, type)`. Because of the unique constraint, this is the only safe way to write without race conditions or duplicates.
- Response: the full management serializer payload (so the editor can reconcile its local state).

### Why these exist as separate endpoints

The existing `ImageTextManagementViewSet` works fine for callers that already know the row id (e.g. clicking a row on the index page). The editor mount path doesn't have that — it knows the image id and the kind from the URL, but not the db id. Without these endpoints, the editor would have to do `GET /image-texts/?item_image=…&type=…` → check `results[0]` → switch between `POST` (none yet) and `PATCH /image-texts/<id>/` (existing). The single-endpoint pair collapses that to one round trip with no branching on the client.

## Test plan

- [x] `pytest apps/manuscripts/tests/test_sole_image_text.py apps/manuscripts/ apps/search/ apps/common/ apps/annotations/` — 83 pass / 1 skip
- [x] `ruff check` and `ruff format --check` — clean
- [ ] `just pytest` — full suite under Postgres + Meilisearch
- [ ] In dev, open `/backoffice/image-texts/<id>` with a fresh image (no row yet), type something, save, refresh, confirm the row persists and the editor reloads its content
- [ ] Hit `/api/v1/manuscripts/item-images/<id>/transcription/` as anonymous against an image whose only Transcription is `Draft` — expect 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
