### PR TITLE
feat(common): EditEvent audit log + signal-driven recording

### DIFF
--- a/apps/annotations/apps.py
+++ b/apps/annotations/apps.py
@@ -4,3 +4,10 @@ from django.apps import AppConfig
 class AnnotationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.annotations"
+
+    def ready(self) -> None:
+        from apps.common.audit import register_audited_models
+
+        from .models import Graph
+
+        register_audited_models(Graph)

--- a/apps/common/audit.py
+++ b/apps/common/audit.py
@@ -1,0 +1,82 @@
+"""Lightweight audit-trail helpers for the EditEvent log.
+
+The event-log table itself lives in ``apps.common`` because every other app is
+allowed to import it. The signal handlers, however, must touch tables that
+``common`` cannot import, so each owning app wires its own post_save /
+post_delete handlers in its ``apps.py`` ready hook (see
+``apps.annotations.apps`` and ``apps.manuscripts.apps``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from django.db.models import Model
+
+from apps.common.models import EditEvent
+
+User = get_user_model()
+
+
+def log_edit(
+    *,
+    actor: Any | None,
+    action: str,
+    target_type: str,
+    target_id: int,
+    summary: str = "",
+    payload: dict | None = None,
+) -> None:
+    EditEvent.objects.create(
+        actor=actor if isinstance(actor, User) else None,
+        action=action,
+        target_type=target_type,
+        target_id=target_id,
+        summary=summary[:255],
+        payload=payload,
+    )
+
+
+def on_save_handler(sender: type[Model], instance: Model, created: bool, **_: Any) -> None:
+    target_type = sender._meta.model_name or sender.__name__.lower()
+    actor = getattr(instance, "_audit_actor", None)
+    summary = ""
+    try:
+        summary = str(instance)[:255]
+    except Exception:
+        summary = ""
+    log_edit(
+        actor=actor,
+        action=EditEvent.Action.CREATED if created else EditEvent.Action.UPDATED,
+        target_type=target_type,
+        target_id=getattr(instance, "pk", 0) or 0,
+        summary=summary,
+    )
+
+
+def on_delete_handler(sender: type[Model], instance: Model, **_: Any) -> None:
+    target_type = sender._meta.model_name or sender.__name__.lower()
+    actor = getattr(instance, "_audit_actor", None)
+    summary = str(instance)[:255] if instance else ""
+    log_edit(
+        actor=actor,
+        action=EditEvent.Action.DELETED,
+        target_type=target_type,
+        target_id=getattr(instance, "pk", 0) or 0,
+        summary=summary,
+    )
+
+
+def register_audited_models(*models: type[Model]) -> None:
+    """Connect ``post_save`` / ``post_delete`` to each model. Idempotent.
+
+    Each owning app calls this once from its ``AppConfig.ready()`` so that
+    ``apps.common`` doesn't have to import models from apps it isn't allowed
+    to depend on.
+    """
+    from django.db.models.signals import post_delete, post_save
+
+    for model in models:
+        post_save.connect(on_save_handler, sender=model, dispatch_uid=f"editevent:{model.__name__}:save")
+        post_delete.connect(on_delete_handler, sender=model, dispatch_uid=f"editevent:{model.__name__}:delete")

--- a/apps/common/migrations/0004_editevent.py
+++ b/apps/common/migrations/0004_editevent.py
@@ -1,0 +1,52 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("common", "0003_alter_date_options"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EditEvent",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("created", "Created"),
+                            ("updated", "Updated"),
+                            ("deleted", "Deleted"),
+                            ("status_changed", "Status changed"),
+                            ("commented", "Commented"),
+                        ],
+                        max_length=24,
+                    ),
+                ),
+                ("target_type", models.CharField(db_index=True, max_length=64)),
+                ("target_id", models.BigIntegerField(db_index=True)),
+                ("summary", models.CharField(blank=True, default="", max_length=255)),
+                ("payload", models.JSONField(blank=True, null=True)),
+                ("created", models.DateTimeField(auto_now_add=True, db_index=True)),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=models.deletion.SET_NULL,
+                        related_name="edit_events",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created"],
+                "indexes": [
+                    models.Index(fields=["target_type", "target_id"], name="editevent_target_idx"),
+                ],
+            },
+        ),
+    ]

--- a/apps/common/models.py
+++ b/apps/common/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 
 
@@ -20,3 +21,41 @@ class Date(models.Model):
     class Meta:
         verbose_name = "Date"
         ordering = ["date"]
+
+
+class EditEvent(models.Model):
+    """Append-only audit log for editor changes (M5.2).
+
+    The viewer / editor surfaces show "X changed Y at Z"; review workflows
+    surface "what changed since last week". The log is decoupled from any one
+    domain table so we can track ImageText / Graph / etc. behind a single tab.
+    """
+
+    class Action(models.TextChoices):
+        CREATED = "created", "Created"
+        UPDATED = "updated", "Updated"
+        DELETED = "deleted", "Deleted"
+        STATUS_CHANGED = "status_changed", "Status changed"
+        COMMENTED = "commented", "Commented"
+
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="edit_events",
+    )
+    action = models.CharField(max_length=24, choices=Action.choices)
+    target_type = models.CharField(max_length=64, db_index=True)  # "graph", "imagetext", …
+    target_id = models.BigIntegerField(db_index=True)
+    summary = models.CharField(max_length=255, blank=True, default="")
+    payload = models.JSONField(null=True, blank=True)
+    created = models.DateTimeField(auto_now_add=True, db_index=True)
+
+    class Meta:
+        ordering = ["-created"]
+        indexes = [
+            models.Index(fields=["target_type", "target_id"], name="editevent_target_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.action} {self.target_type}#{self.target_id} by {self.actor_id} @ {self.created}"

--- a/apps/common/serializers.py
+++ b/apps/common/serializers.py
@@ -1,9 +1,28 @@
 from rest_framework import serializers
 
-from apps.common.models import Date
+from apps.common.models import Date, EditEvent
 
 
 class DateManagementSerializer(serializers.ModelSerializer):
     class Meta:
         model = Date
         fields = ["id", "date", "min_weight", "max_weight"]
+
+
+class EditEventSerializer(serializers.ModelSerializer):
+    actor_username = serializers.CharField(source="actor.username", read_only=True)
+
+    class Meta:
+        model = EditEvent
+        fields = [
+            "id",
+            "actor",
+            "actor_username",
+            "action",
+            "target_type",
+            "target_id",
+            "summary",
+            "payload",
+            "created",
+        ]
+        read_only_fields = fields

--- a/apps/common/tests/test_audit.py
+++ b/apps/common/tests/test_audit.py
@@ -1,0 +1,169 @@
+"""Tests for the EditEvent audit-log helpers.
+
+Pinned behaviour:
+  - log_edit creates an EditEvent with the actor (only when it's a real user)
+  - on_save_handler emits CREATED on first insert, UPDATED on subsequent saves
+  - on_delete_handler emits DELETED
+  - summary is truncated to 255 chars and falls back to "" if str(instance) raises
+  - register_audited_models is idempotent — calling twice doesn't double-emit
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django.contrib.auth import get_user_model
+from django.db.models.signals import post_delete, post_save
+import pytest
+
+from apps.common.audit import (
+    log_edit,
+    on_delete_handler,
+    on_save_handler,
+    register_audited_models,
+)
+from apps.common.models import EditEvent
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestLogEdit:
+    def test_creates_event_with_actor(self):
+        user = User.objects.create(username="alice")
+        log_edit(
+            actor=user,
+            action=EditEvent.Action.CREATED,
+            target_type="graph",
+            target_id=42,
+            summary="hello",
+        )
+        event = EditEvent.objects.get()
+        assert event.actor == user
+        assert event.action == EditEvent.Action.CREATED
+        assert event.target_type == "graph"
+        assert event.target_id == 42
+        assert event.summary == "hello"
+
+    def test_drops_actor_when_not_a_user(self):
+        # log_edit accepts any object as actor but only persists it if it
+        # is actually a User instance — protects against passing string IDs
+        # or stale references.
+        log_edit(
+            actor="not-a-user",
+            action=EditEvent.Action.UPDATED,
+            target_type="graph",
+            target_id=1,
+        )
+        event = EditEvent.objects.get()
+        assert event.actor is None
+
+    def test_summary_truncated_at_255(self):
+        log_edit(
+            actor=None,
+            action=EditEvent.Action.UPDATED,
+            target_type="graph",
+            target_id=1,
+            summary="x" * 500,
+        )
+        event = EditEvent.objects.get()
+        assert len(event.summary) == 255
+
+    def test_payload_round_trip(self):
+        log_edit(
+            actor=None,
+            action=EditEvent.Action.STATUS_CHANGED,
+            target_type="imagetext",
+            target_id=7,
+            payload={"from": "Draft", "to": "Live"},
+        )
+        event = EditEvent.objects.get()
+        assert event.payload == {"from": "Draft", "to": "Live"}
+
+
+class _FakeSender:
+    """Stand-in for a model class — only `_meta.model_name` and `__name__` are read."""
+
+    __name__ = "FakeModel"
+    _meta = SimpleNamespace(model_name="fakemodel")
+
+
+@pytest.mark.django_db
+class TestOnSaveHandler:
+    def test_created_action_when_created_true(self):
+        instance = SimpleNamespace(pk=1, _audit_actor=None)
+        on_save_handler(sender=_FakeSender, instance=instance, created=True)
+        event = EditEvent.objects.get()
+        assert event.action == EditEvent.Action.CREATED
+        assert event.target_type == "fakemodel"
+        assert event.target_id == 1
+
+    def test_updated_action_when_created_false(self):
+        instance = SimpleNamespace(pk=1, _audit_actor=None)
+        on_save_handler(sender=_FakeSender, instance=instance, created=False)
+        event = EditEvent.objects.get()
+        assert event.action == EditEvent.Action.UPDATED
+
+    def test_falls_back_to_classname_when_no_meta_model_name(self):
+        sender = type("Bare", (), {"__name__": "Bare", "_meta": SimpleNamespace(model_name=None)})
+        instance = SimpleNamespace(pk=99, _audit_actor=None)
+        on_save_handler(sender=sender, instance=instance, created=True)
+        event = EditEvent.objects.get()
+        assert event.target_type == "bare"
+
+    def test_summary_falls_back_to_empty_when_str_raises(self):
+        # If __str__ blows up (broken model state), the handler should still
+        # log the event with an empty summary instead of bubbling the error.
+        class _ExplodingStr:
+            pk = 5
+            _audit_actor = None
+
+            def __str__(self):
+                raise RuntimeError("kaboom")
+
+        on_save_handler(sender=_FakeSender, instance=_ExplodingStr(), created=True)
+        event = EditEvent.objects.get()
+        assert event.summary == ""
+
+    def test_actor_is_picked_up_from_audit_actor(self):
+        user = User.objects.create(username="bob")
+        instance = SimpleNamespace(pk=11, _audit_actor=user)
+        on_save_handler(sender=_FakeSender, instance=instance, created=True)
+        event = EditEvent.objects.get()
+        assert event.actor == user
+
+    def test_target_id_zero_when_pk_missing(self):
+        instance = SimpleNamespace(pk=None, _audit_actor=None)
+        on_save_handler(sender=_FakeSender, instance=instance, created=True)
+        event = EditEvent.objects.get()
+        assert event.target_id == 0
+
+
+@pytest.mark.django_db
+class TestOnDeleteHandler:
+    def test_emits_deleted_action(self):
+        instance = SimpleNamespace(pk=3, _audit_actor=None)
+        on_delete_handler(sender=_FakeSender, instance=instance)
+        event = EditEvent.objects.get()
+        assert event.action == EditEvent.Action.DELETED
+        assert event.target_type == "fakemodel"
+        assert event.target_id == 3
+
+
+@pytest.mark.django_db
+class TestRegisterAuditedModels:
+    def test_register_is_idempotent(self):
+        # Two calls with the same model should not result in two events
+        # per save — dispatch_uid de-duplicates the connection.
+        from apps.users.tests.factories import UserFactory
+
+        register_audited_models(User)
+        register_audited_models(User)
+        try:
+            EditEvent.objects.all().delete()
+            UserFactory()
+            assert EditEvent.objects.filter(target_type="user").count() == 1
+        finally:
+            # Clean up the connection so other tests don't leak this signal.
+            post_save.disconnect(on_save_handler, sender=User, dispatch_uid="editevent:User:save")
+            post_delete.disconnect(on_delete_handler, sender=User, dispatch_uid="editevent:User:delete")

--- a/apps/common/urls.py
+++ b/apps/common/urls.py
@@ -1,8 +1,9 @@
 from rest_framework.routers import DefaultRouter
 
-from .views import DateManagementViewSet
+from .views import DateManagementViewSet, EditEventListViewSet
 
 router = DefaultRouter()
 router.register("management/common/dates", DateManagementViewSet, basename="management-dates")
+router.register("common/edit-events", EditEventListViewSet, basename="common-edit-events")
 
 urlpatterns = router.urls

--- a/apps/common/views.py
+++ b/apps/common/views.py
@@ -11,10 +11,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 import yaml
 
-from apps.common.models import Date
+from apps.common.models import Date, EditEvent
 from apps.common.permissions import IsSuperuser
 
-from .serializers import DateManagementSerializer
+from .serializers import DateManagementSerializer, EditEventSerializer
 
 
 class BasePrivilegedViewSet(viewsets.ModelViewSet):
@@ -97,3 +97,16 @@ class SwaggerUIView(TemplateView):
 class DateManagementViewSet(UnpaginatedPrivilegedViewSet):
     queryset = Date.objects.all()
     serializer_class = DateManagementSerializer
+
+
+class EditEventListViewSet(viewsets.ReadOnlyModelViewSet):
+    """Read-only audit log feed.
+
+    Filterable by ``target_type``, ``target_id``, and ``actor`` so the viewer
+    can show "history for this annotation" with a single request.
+    """
+
+    queryset = EditEvent.objects.select_related("actor").all()
+    serializer_class = EditEventSerializer
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_fields = ["target_type", "target_id", "actor", "action"]

--- a/apps/manuscripts/apps.py
+++ b/apps/manuscripts/apps.py
@@ -5,3 +5,10 @@ class ManuscriptsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.manuscripts"
     verbose_name = "Manuscripts"
+
+    def ready(self) -> None:
+        from apps.common.audit import register_audited_models
+
+        from .models import ImageText
+
+        register_audited_models(ImageText)


### PR DESCRIPTION
## Summary

A small append-only audit table (`EditEvent`) and the signal plumbing that emits one row per insert / update / delete on registered models. The frontend annotation side-rail will read this back through `/api/v1/common/edit-events/?target_type=graph&target_id=…` to render a "history for this annotation" feed in a single call.

### Schema

`apps/common/models.py` — `EditEvent`:
- `actor` FK to user (`SET_NULL`, nullable)
- `action`: `created` / `updated` / `deleted` / `status_changed` / `commented`
- `target_type` (string, indexed) + `target_id` (bigint, indexed) — decoupled from any one domain table so the same log covers Graph / ImageText / future models
- `summary` (truncated `str(instance)`), `payload` (free-form JSON), `created` (auto, indexed)
- composite index on `(target_type, target_id)` for the side-rail's hot query

Migration `0004_editevent`.

### Helpers

`apps/common/audit.py`:
- `register_audited_models(*models)` — wires `post_save` and `post_delete` handlers per model. Idempotent (calling twice doesn't double-emit). Each owning app calls this from its `AppConfig.ready` because `apps.common` can't import domain tables.
- `log_edit(*, actor, action, target_type, target_id, summary, payload)` — explicit helper for non-CRUD events (status transitions, comment posts) where the action enum doesn't fit the `created`/`updated`/`deleted` pattern.
- Signal handlers pull the actor from `instance._audit_actor` if a viewset stamped it on the instance pre-save, otherwise the row is recorded anonymously.

### Endpoint

`GET /api/v1/common/edit-events/`:
- Read-only, default DRF permissions (anonymous can read; same as the existing public `image-texts` endpoint pattern).
- Filterable by `target_type`, `target_id`, `actor`, `action`. The side-rail call is `?target_type=graph&target_id=42`.

### Wiring

- `apps/annotations/apps.py` registers `Graph`.
- `apps/manuscripts/apps.py` registers `ImageText`.

(Other models — `AnnotationComment`, `StatusTransition` — can register themselves the same way without `apps.common` having to import them.)

## Test plan

- [x] `apps/common/tests/test_audit.py` covers: `log_edit` happy path, anonymous actor, summary truncation to 255 chars, fallback when `str(instance)` raises, signal handlers emit `CREATED` on first save and `UPDATED` on subsequent saves, `DELETED` on delete, `register_audited_models` is idempotent.
- [x] `pytest apps/common/ apps/manuscripts/ apps/annotations/` — 51 pass, 1 skip
- [x] `ruff check` and `ruff format --check` — clean
- [ ] `just pytest` — full suite under Postgres + Meilisearch
- [ ] In dev, edit a Graph through the existing management endpoint, hit `/api/v1/common/edit-events/?target_type=graph&target_id=<id>` and confirm one `created`-then-`updated` pair shows up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
