### PR TITLE
Use config/.env in Django settings.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+config/.env
 .env
 .venv
 env/

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,9 +6,9 @@ import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 import environ
 
-# Load .env from project root when running outside Docker (e.g. manage.py runserver, pytest)
+# Load .env from config/ when running outside Docker (e.g. manage.py runserver, pytest)
 BASE_DIR = Path(__file__).resolve().parent.parent
-_env_file = BASE_DIR / ".env"
+_env_file = BASE_DIR / "config" / ".env"
 environ.Env.read_env(_env_file)
 
 env = environ.Env(


### PR DESCRIPTION
Hello, 

I face two times issue on my variable environment in the backend container. 
I was having two .env file, one at the root and an other inside `config` folder. I guess it was coming from my previous work on the subject (4e7ea67bbea4a4e5fedc18098dcc15ffc5cdb6d8) 

Also on 78b99e46e555b418a518892ec7165b35f596c9b8, @lanterno  fixed the .env file use by Just  command on `config/.env`

I double check all the project and I find a last inconstancy