### PR TITLE
fix(annotations): block non-superusers from making an annotation editorial

### DIFF
--- a/apps/annotations/tests/test_editorial_guard.py
+++ b/apps/annotations/tests/test_editorial_guard.py
@@ -1,0 +1,61 @@
+"""Non-superusers must not be able to PATCH an annotation to editorial (#158).
+
+perform_create already blocks creating editorial graphs; without the matching
+update guard, a non-superuser could flip annotation_type on an existing graph
+and silently lock themselves out — the viewer-write queryset excludes editorial
+rows for them, so the row would 404 on every subsequent request of theirs.
+"""
+
+import pytest
+import rest_framework
+
+from apps.annotations.models import Graph
+from apps.annotations.tests.factories import GraphFactory
+
+VIEWER_URL = "/api/v1/annotations/graphs/"
+
+
+@pytest.mark.django_db
+def test_non_superuser_cannot_patch_annotation_to_editorial(authenticated_client):
+    graph = GraphFactory(annotation_type=Graph.AnnotationType.IMAGE)
+
+    response = authenticated_client.patch(
+        f"{VIEWER_URL}{graph.id}/",
+        data={"annotation_type": Graph.AnnotationType.EDITORIAL},
+        format="json",
+    )
+
+    assert response.status_code == rest_framework.status.HTTP_403_FORBIDDEN, response.data
+    graph.refresh_from_db()
+    assert graph.annotation_type == Graph.AnnotationType.IMAGE
+
+
+@pytest.mark.django_db
+def test_non_superuser_patch_without_type_change_still_works(authenticated_client):
+    graph = GraphFactory(annotation_type=Graph.AnnotationType.IMAGE)
+
+    response = authenticated_client.patch(
+        f"{VIEWER_URL}{graph.id}/",
+        data={"note": "still editable"},
+        format="json",
+    )
+
+    assert response.status_code == rest_framework.status.HTTP_200_OK, response.data
+    graph.refresh_from_db()
+    assert graph.note == "still editable"
+    assert graph.annotation_type == Graph.AnnotationType.IMAGE
+
+
+@pytest.mark.django_db
+def test_superuser_can_patch_annotation_to_editorial(management_client):
+    graph = GraphFactory(annotation_type=Graph.AnnotationType.IMAGE)
+
+    response = management_client.patch(
+        f"{VIEWER_URL}{graph.id}/",
+        data={"annotation_type": Graph.AnnotationType.EDITORIAL},
+        format="json",
+    )
+
+    assert response.status_code == rest_framework.status.HTTP_200_OK, response.data
+    graph.refresh_from_db()
+    assert graph.annotation_type == Graph.AnnotationType.EDITORIAL

--- a/apps/annotations/views.py
+++ b/apps/annotations/views.py
@@ -72,6 +72,17 @@ class GraphViewerWriteViewSet(AuditActorMixin, viewsets.ModelViewSet):
                 raise PermissionDenied("Only superusers can create editorial annotations.")
         super().perform_create(serializer)
 
+    def perform_update(self, serializer):
+        # Mirrors perform_create: without this, a non-superuser could PATCH an
+        # annotation *to* editorial and lock themselves out (the queryset above
+        # hides editorial rows from them, so they could never revert it). The
+        # reverse direction needs no guard — editorial rows 404 for them here.
+        user = getattr(self.request, "user", None)
+        if not getattr(user, "is_superuser", False):
+            if serializer.validated_data.get("annotation_type") == Graph.AnnotationType.EDITORIAL:
+                raise PermissionDenied("Only superusers can make an annotation editorial.")
+        super().perform_update(serializer)
+
 
 class GraphManagementViewSet(ActionSerializerMixin, FilterablePrivilegedViewSet):
     queryset = (


### PR DESCRIPTION
Closes #158. perform_create already blocked creating editorial annotations for non-superusers, but there was no equivalent guard on update and annotation_type is writable - any authenticated user could PATCH an annotation to editorial.